### PR TITLE
Avoid import meta in the transpiled code with a babel plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ workflows:
       - test:
           docker_image: circleci/node:12-browsers
       - test:
-          docker_image: circleci/node:13-browsers
-      - test:
           docker_image: circleci/node:14-browsers
       - test:
           docker_image: circleci/node:16-browsers

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,9 +52,9 @@ module.exports = function(grunt) {
                     "add-module-exports",
                     "@babel/plugin-transform-regenerator"
                 ],
-                comments: false, // debug,
-                compact: false, // !debug,
-                minified: false, // !debug
+                comments: debug,
+                compact: !debug,
+                minified: !debug
             },
             dist: {
                 files: [{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,12 +48,13 @@ module.exports = function(grunt) {
                     }
                 ]],
                 plugins: [
+                    "transform-import-meta",
                     "add-module-exports",
                     "@babel/plugin-transform-regenerator"
                 ],
-                comments: debug,
-                compact: !debug,
-                minified: !debug
+                comments: false, // debug,
+                compact: false, // !debug,
+                minified: false, // !debug
             },
             dist: {
                 files: [{

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.1
+
+* remove references to import.meta in the transpiled code so that it
+  runs properly when you require() this package
+
 ### v1.0.0
 
 - initial version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-istring",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {


### PR DESCRIPTION
Without this, node will complain that `import.meta` is not accessible outside of an ES module.